### PR TITLE
feat: make checkpoint interval default value back to 10

### DIFF
--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -274,7 +274,7 @@ impl<'a> TableConfig<'a> {
             DeltaConfigKey::CheckpointInterval,
             checkpoint_interval,
             i32,
-            100
+            10
         ),
     );
 


### PR DESCRIPTION
The default value changed from 100 to 10 in commit https://github.com/delta-io/delta-rs/commit/5eade5e1f07e80ecd053bd538e005894b7e88a8f; this PR is to restore the origin 10 value for internal use.